### PR TITLE
A cron job that checks for broken links

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -123,7 +123,21 @@ trigger:
   target:
     - production
 ---
+kind: pipeline
+type: docker
+name: link-checker
+trigger:
+  event:
+  - cron
+  cron:
+    - link-checker
+steps:
+  - name: link-checker
+    image: tennox/linkcheck
+    commands:
+      - linkcheck --external --no-show-redirects https://docs.zerotier.com --skip-file <(echo "example.com\nlocalhost")
+---
 kind: signature
-hmac: 2d5dd34d302fc510c14de0b8579bdd8bb7456a3faa6954ec7fad13642a1818eb
+hmac: 51d3fed16fed56c761eabade1684402c724111c3e5ea02b92751716069832405
 
 ...


### PR DESCRIPTION
example here http://drone.ci.lab/zerotier/docs/242/1/2

There are quite a few broken/decayed links on the current live site so

runs monthly against https://docs.zerotier.com
schedule can be changed in the drone ui.
link checking take a while to run, and is flakey
because the internet, so i didn't want to
run it on every push/pr and fail builds 
when people are trying to work

run manually with:

`drone cron exec zerotier/docs link-checker`