### PR TITLE
Convert curly quotes to plain quotes

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,11 +7,11 @@ description: Did you check your spam folder?
 
 If you are not receiving password reset emails, first check your Spam/Junk Mail folder.
 
-If it’s not in your Spam/Junk Mail folder, contact your email administrator to ensure emails from <my@zerotier.com> are not being blocked at the server level.
+If it's not in your Spam/Junk Mail folder, contact your email administrator to ensure emails from <my@zerotier.com> are not being blocked at the server level.
 
 ### Changing Your Email Address
 
-Log into ZeroTier Central at <https://my.zerotier.com>. Once logged in, there's a "Manage Account" link on the Account page.  Click that and then “Personal Info” and you'll be taken to a form where you can change your email address.
+Log into ZeroTier Central at <https://my.zerotier.com>. Once logged in, there's a "Manage Account" link on the Account page.  Click that and then "Personal Info" and you'll be taken to a form where you can change your email address.
 
 ### Invalid Authenticator Code
 
@@ -19,7 +19,7 @@ This can be caused by the time being wrong on your computer or phone.
 
 ### Lost Authenticator Code
 
-Use the Password Reset flow. Click “forgot password” on the login screen.
+Use the Password Reset flow. Click "forgot password" on the login screen.
 
 :::info Historical
 If you have not logged in to your account since 2019

--- a/docs/bridging.md
+++ b/docs/bridging.md
@@ -3,7 +3,7 @@ title: Layer 2 Bridge
 description: Bridge your physical LAN to ZeroTier using a Raspberry Pi
 ---
 
-Do you have devices that can’t run ZeroTier that you want to access remotely? You can use a small linux PC as a bridge between ZeroTier and physical networks.
+Do you have devices that can't run ZeroTier that you want to access remotely? You can use a small linux PC as a bridge between ZeroTier and physical networks.
 
 :::info Note
 This topic is related to but different from using ZeroTier as a Layer 5 [Service Proxy](proxy).
@@ -11,11 +11,11 @@ This topic is related to but different from using ZeroTier as a Layer 5 [Service
 
 ### Assumptions
 
-- You’re doing this on your home network and can log in to your router and find the DHCP settings.
-- You have a keyboard, monitor, and ethernet cable plugged into your Pi. Chances are high we’ll break networking and lose access to the Pi.
-- You’re somewhat familiar with the command line, ssh.
-- We’re going to use systemd networking for this. You could probably adapt the concepts to a different linux network configuration system if you have opinions about systemd.
-- We used a raspberry Pi 2 while writing this, but a Pi 3 or 4 should work fine. Anything running a Debian 10+ based distro should be fine. It doesn’t have a be a Raspberry Pi, but some of these instructions might be raspbian specific.
+- You're doing this on your home network and can log in to your router and find the DHCP settings.
+- You have a keyboard, monitor, and ethernet cable plugged into your Pi. Chances are high we'll break networking and lose access to the Pi.
+- You're somewhat familiar with the command line, ssh.
+- We're going to use systemd networking for this. You could probably adapt the concepts to a different linux network configuration system if you have opinions about systemd.
+- We used a raspberry Pi 2 while writing this, but a Pi 3 or 4 should work fine. Anything running a Debian 10+ based distro should be fine. It doesn't have a be a Raspberry Pi, but some of these instructions might be raspbian specific.
 
 ### What you'll need
 
@@ -25,7 +25,7 @@ This topic is related to but different from using ZeroTier as a Layer 5 [Service
 - Default Gateway IP Address (the router)
 - Bridge IP Address (will be statically assigned)
 - Create a new ZeroTier network and get the ID. Keep an old network around for secondary way to connect any devices already using ZeroTier.
-- The DHCP range and ZeroTier Auto-Assign range should be in the same subnet, but not overlap. You’d probably base this off what is already configured on your router.
+- The DHCP range and ZeroTier Auto-Assign range should be in the same subnet, but not overlap. You'd probably base this off what is already configured on your router.
 
 #### An example plan
 
@@ -49,7 +49,7 @@ This topic is related to but different from using ZeroTier as a Layer 5 [Service
 
 ### SSH into the Pi
 
-It’s easier to login via ssh now and copy/paste commands from the comfort of your own PC.
+It's easier to login via ssh now and copy/paste commands from the comfort of your own PC.
 
 The DNS name might just work for you:
 
@@ -61,7 +61,7 @@ The DNS name might just work for you:
 sudo apt update && sudo apt -y full-upgrade && sudo reboot
 ```
 
-Log back in after it’s done
+Log back in after it's done
 
 ### Install ZeroTier
 
@@ -69,7 +69,7 @@ Log back in after it’s done
 curl -s https://install.zerotier.com | sudo bash
 ```
 
-### Let’s set some shell variables now
+### Let's set some shell variables now
 
 ```sh
 NETWORK_ID=<your-network-id>
@@ -84,7 +84,7 @@ GW_ADDR=<your-gateway-address>
 sudo zerotier-cli join $NETWORK_ID
 ```
 
-We don’t want ZeroTier to manage addresses or routes on `$ZT_IF`. We’re doing it statically below, on the bridge interface.
+We don't want ZeroTier to manage addresses or routes on `$ZT_IF`. We're doing it statically below, on the bridge interface.
 
 ```sh
 sudo zerotier-cli set $NETWORK_ID allowManaged=0
@@ -183,7 +183,7 @@ You should be able to, from the physical LAN, connect to the Pi via `$BR_ADDR`
 
 ### If it takes a long time waiting for the network during boot
 
-Sometimes the physical interface turns out to be a long “predicatable interface name” like: “enb827eb0d4176”, sometimes it’s just `eth0`, depending on raspbian version(???).
+Sometimes the physical interface turns out to be a long "predicatable interface name" like: "enb827eb0d4176", sometimes it's just `eth0`, depending on raspbian version(???).
 
 <https://wiki.debian.org/NetworkConfiguration#Network_Interface_Names>
 
@@ -200,7 +200,7 @@ At `my.zerotier.com/network/$NETWORK_ID`->`Settings`->`Advanced`
 
 ### It should be working now. Next steps
 
-Either it worked, and you can ssh back in to `$BR_ADDR` after a minute, or it didn’t work and the Pi isn’t on the network anymore and you need to use the keyboard and monitor to figure out what went wrong.
+Either it worked, and you can ssh back in to `$BR_ADDR` after a minute, or it didn't work and the Pi isn't on the network anymore and you need to use the keyboard and monitor to figure out what went wrong.
 
 :::tip
 Make a backup of the sd card so you don't have to repeat these steps
@@ -230,11 +230,11 @@ See: <https://serverfault.com/questions/162366/iptables-bridge-and-forward-chain
 
 #### Why is the Managed Route /23 and the LAN subnet /24?
 
-Say you have a laptop that is on the ZeroTier network and you bring it home. Now it’s WiFi address and ZeroTier address are in the same subnet. Which interface/address should your laptop use for internet access? <https://en.wikipedia.org/wiki/Longest_prefix_match>
+Say you have a laptop that is on the ZeroTier network and you bring it home. Now it's WiFi address and ZeroTier address are in the same subnet. Which interface/address should your laptop use for internet access? <https://en.wikipedia.org/wiki/Longest_prefix_match>
 
 ### Why is an app on my phone not working over ZeroTier?
 
-Unfortunately the iOS and Android VPN APIs won’t let ZeroTier use multicast/broadcast. These are typically how apps auto-discover services on the LAN. 😭 Stay tuned for an article on bridging a ZeroTier network and a WiFi access point.
+Unfortunately the iOS and Android VPN APIs won't let ZeroTier use multicast/broadcast. These are typically how apps auto-discover services on the LAN. 😭 Stay tuned for an article on bridging a ZeroTier network and a WiFi access point.
 
 ### References
 

--- a/docs/central-admins.md
+++ b/docs/central-admins.md
@@ -7,7 +7,7 @@ Professional subscriptions have a shared administration feature.
 
 ![Add User](./images/central-admin-01.png)
 
-Toward the bottom of a Network’s page. There is a section titled “Administrators”
+Toward the bottom of a Network's page. There is a section titled "Administrators"
 
 A user must be a member of your [Organization](./organizations.md) to become a Network Administrator.
 

--- a/docs/central-billing.md
+++ b/docs/central-billing.md
@@ -12,17 +12,17 @@ It will take you to this page where you can update information and download invo
 
 ![Manage Billing](./images/central-billing-02.png)
 
-### I don't see a “Manage Billing” button
+### I don't see a "Manage Billing" button
 
 Only the Organization Owner can edit billing info. The account page will show who your Organization Owner is, if it is not you.
 
 ### If the address is incorrect on your invoice
 
-Please use the Update Information link. If possible, use Address Line 1 for your company name. And Line 2 for your address. If it doesn’t fit please contact us.
+Please use the Update Information link. If possible, use Address Line 1 for your company name. And Line 2 for your address. If it doesn't fit please contact us.
 
-After changing the address, use the *download invoice* link. If too much time has passed since the invoice was finalized, it won’t be updated. Sorry.
+After changing the address, use the *download invoice* link. If too much time has passed since the invoice was finalized, it won't be updated. Sorry.
 
-### My invoices don’t show my Tax ID #
+### My invoices don't show my Tax ID #
 
 ZeroTier's US Tax ID is 47-3126707. We aren't incorporated outside of the US so we don't have a Tax ID for anywhere outside of the US. Our payment processor will not print your Tax ID on invoices for this reason.
 
@@ -30,6 +30,6 @@ If you need a Tax ID in order to purchase ZeroTier, consider reaching out to a l
 
 ### How to delete your whole account
 
-Go to your [account page](https://my.zerotier.com/account) and click on the “delete account” button.
+Go to your [account page](https://my.zerotier.com/account) and click on the "delete account" button.
 
 This deletes everything about your account, in accordance with various privacy laws.

--- a/docs/central-hide-nodes.md
+++ b/docs/central-hide-nodes.md
@@ -11,11 +11,11 @@ There are delete and hide buttons on the right side of the list nodes in the Mem
 
 The member will be de-authorized and hidden from view in the list.
 
-Hidden members can be revealed by setting the “Hidden” checkbox above the member’s list.
+Hidden members can be revealed by setting the "Hidden" checkbox above the member's list.
 
 ### Deleting a Member
 
-The member will be de-authorized and completely removed from the list. It’s a little more permanent than hiding.
+The member will be de-authorized and completely removed from the list. It's a little more permanent than hiding.
 
 ### Recover a Deleted Member
 
@@ -27,12 +27,12 @@ You've deleted a member from your network, possibly by accident, and you want to
 
 ![Manually add member](./images/central-hide-nodes-02.png)
 
-If you’ve lost Node ID, it can be viewed on the device -in the ZeroTier app.
+If you've lost Node ID, it can be viewed on the device -in the ZeroTier app.
 
-Delete should only be used if the node will never join again. Just de-authorize them instead if you don’t want them counted against your node limits.
-If you don’t see the Delete and Hide Buttons
+Delete should only be used if the node will never join again. Just de-authorize them instead if you don't want them counted against your node limits.
+If you don't see the Delete and Hide Buttons
 
-You have likely turned off your network’s access control by setting it  to Public.
+You have likely turned off your network's access control by setting it  to Public.
 
 Public networks have no access control. If you deleted or de-authorized a member it would reappear within a few seconds.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ zerotier-cli listnetworks
 ```
 
 :::info
-If you see `missing authentication token and authtoken.secret not found (or readable)` you’re likely trying to run `zerotier-cli` from a non-administrative account. On macOS, Linux, or other Unix based systems, use sudo `zerotier-cli`. On Windows, use an Administrator Command Prompt.
+If you see `missing authentication token and authtoken.secret not found (or readable)` you're likely trying to run `zerotier-cli` from a non-administrative account. On macOS, Linux, or other Unix based systems, use sudo `zerotier-cli`. On Windows, use an Administrator Command Prompt.
 :::
 
 ### Network Join Status Codes

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,7 +13,7 @@ site](https://www.zerotier.com/download.shtml) and source code is found
 on [GitHub](https://github.com/zerotier/ZeroTierOne).
 
 After the service is installed and started, networks can be joined using
-their 16-digit network IDs. Each network appears as a virtual “tap”
+their 16-digit network IDs. Each network appears as a virtual "tap"
 network port on your system that behaves just like an ordinary Ethernet
 port.
 
@@ -125,7 +125,7 @@ does not allow comments):
 
 - **trustedPathId**: A trusted path is a physical network over which
     encryption and authentication are not required. This provides a
-    performance boost but sacrifices all ZeroTier’s security features
+    performance boost but sacrifices all ZeroTier's security features
     when communicating over this path. *Only use this feature if you
     know what you are doing and really need the performance!* To set up
     a trusted path, all devices on the same trusted physical network

--- a/docs/corporate-firewalls.md
+++ b/docs/corporate-firewalls.md
@@ -3,25 +3,25 @@ title: Corporate Firewalls
 decription: How to make direct connections through a corporate firewall
 ---
 
-There are 3 classes of nodes in a working ZeroTier system: The roots, a controller, and your devices. Your devices need to be able to communicate directly with each other. ZeroTier uses UDP hole punching to do this. It’s a similar process to VoIP STUN/TURN. The difficulty for strict firewall configurations is: the my.zerotier.com controllers and your devices are on dynamic IP addresses and are listening on random UDP ports.
+There are 3 classes of nodes in a working ZeroTier system: The roots, a controller, and your devices. Your devices need to be able to communicate directly with each other. ZeroTier uses UDP hole punching to do this. It's a similar process to VoIP STUN/TURN. The difficulty for strict firewall configurations is: the my.zerotier.com controllers and your devices are on dynamic IP addresses and are listening on random UDP ports.
 
 Default zerotier-one listening ports are:
 
 - 9993
-- Secondary Port, randomized each start up and after being “offline” for too long.
+- Secondary Port, randomized each start up and after being "offline" for too long.
 - Random Port for UPnP and NATPMP (UPnP or NATPMP is not required for ZeroTier hole punching to work)
 
-For best results, a device needs be able to send to any IP address, on any UDP port. If you allow outgoing source:9993 and incoming related return traffic, it’ll probably work OK.
+For best results, a device needs be able to send to any IP address, on any UDP port. If you allow outgoing source:9993 and incoming related return traffic, it'll probably work OK.
 
-If the NAT type is “symmetric” or “strict” or “endpoint dependent mapping” (each vendor uses different terminology) NAT it will be difficult to make direct connections.
+If the NAT type is "symmetric" or "strict" or "endpoint dependent mapping" (each vendor uses different terminology) NAT it will be difficult to make direct connections.
 
 Look for Full Cone NAT, options related to VoIP, persistent NAT, Endpoint Independent Mapping, etc…
 
 Ask your vendor. Let us know what works.
 
-If you are behind a Palo Alto, you will need some kind of ZeroTier bastion. As far as we know, there’s no way to enable endpoint independent mapping. Contact us for help.
+If you are behind a Palo Alto, you will need some kind of ZeroTier bastion. As far as we know, there's no way to enable endpoint independent mapping. Contact us for help.
 
-Here’s a table of the likeliness of a direct connection between two types of NAT:
+Here's a table of the likeliness of a direct connection between two types of NAT:
 
 |NAT type|Hard|Easy|None (WAN)|
 |-|-|-|-|
@@ -33,10 +33,10 @@ And a network diagram:
 
 ![Network diagram](./images/corporate-firewall-01.png)
 
-### How do I know if I’m behind a Difficult NAT?
+### How do I know if I'm behind a Difficult NAT?
 
 - Check zerotier-cli info -j and look at the surfaceAddresses. If that list is growing, you may be behind a difficult NAT.
-- Check zerotier-cli peers and see if connections to peers you care about are “relayed”
+- Check zerotier-cli peers and see if connections to peers you care about are "relayed"
 
 :::tip
 See also: [Router Configuration Tips](./routertips.md)

--- a/docs/dns-management.md
+++ b/docs/dns-management.md
@@ -6,7 +6,7 @@ description: DNS Management
 :::info
 DNS integration is a long-requested feature. In 1.6 it is now possible to set DNS servers at the network controller that will be applied to the host upon joining the network, provided the host approves this by allowing managed DNS. This will allow networks to push things like Active Directory or other intranet DNS servers to members of a network.
 
-This still doesn’t let you simply address hosts by their name as configured at the controller, but we’re aware of this. We plan on adding a feature to allow the controller itself to be a DNS server too if one desires in a future ZeroTier version (likely post-2.0).
+This still doesn't let you simply address hosts by their name as configured at the controller, but we're aware of this. We plan on adding a feature to allow the controller itself to be a DNS server too if one desires in a future ZeroTier version (likely post-2.0).
 
 In the mean time, have a look at [GitHub - zerotier/zeronsd: A DNS server for ZeroTier users](https://github.com/zerotier/zeronsd), a DNS server for your [ZeroTier Central](https://my.zerotier.com) networks.
 :::
@@ -17,7 +17,7 @@ Configuration is done at the [my.zerotier.com](https://my.zerotier.com) network 
 
 ![DNS Configuration section in Central](./images/dns-management-00.png)
 
-Each client must click the “Allow DNS” button.
+Each client must click the "Allow DNS" button.
 
 ![Allow DNS button](./images/dns-management-01.png)
 
@@ -27,7 +27,7 @@ Some group policies can prevent managed DNS from working. See fix here [New DNS 
 
 ### macOS DNS resolution
 
-On macOS, common command line DNS tools like dig, host, and nslookup don’t know about these types of resolvers, and do not work with ZeroTier Managed DNS.
+On macOS, common command line DNS tools like dig, host, and nslookup don't know about these types of resolvers, and do not work with ZeroTier Managed DNS.
 
 Here are some macOS specific alternatives:
 
@@ -39,7 +39,7 @@ ping and curl should work too.
 
 ### Alternatively
 
-It’s also possible to put your ZeroTier Managed IP Addresses in public DNS. That is, purchase a domain name from a registrar and create A and/or AAAA records that point to your virtual IP addresses.
+It's also possible to put your ZeroTier Managed IP Addresses in public DNS. That is, purchase a domain name from a registrar and create A and/or AAAA records that point to your virtual IP addresses.
 
 :::tip
 [See community threads about DNS](https://discuss.zerotier.com/search?q=dns)

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -11,9 +11,9 @@ The information below applies to any devices still in the field.
 
 ### Networking Information
 
-Each ZeroTier Edge is initialized with a factory default ZeroTier identity. This identity (which doubles as a serial number) is printed above the power connector. Coupled with ZeroTier’s ad-hoc networking capability this provides an easy way to reach the device for initial configuration.
+Each ZeroTier Edge is initialized with a factory default ZeroTier identity. This identity (which doubles as a serial number) is printed above the power connector. Coupled with ZeroTier's ad-hoc networking capability this provides an easy way to reach the device for initial configuration.
 
-Each Edge device joins the IPv6-unicast-only “ad-hoc” ZeroTier network `ff001601bb000000` and can be reached through this network by joining it from any PC or mobile device and then navigating to your device’s unique IPv6 virtual address.
+Each Edge device joins the IPv6-unicast-only "ad-hoc" ZeroTier network `ff001601bb000000` and can be reached through this network by joining it from any PC or mobile device and then navigating to your device's unique IPv6 virtual address.
 
 #### Your device can be reached at
 
@@ -23,11 +23,11 @@ Each Edge device joins the IPv6-unicast-only “ad-hoc” ZeroTier network `ff0
 |HTTP|`http://[fc44:16:1##:####:####::1]/`|
 |SSH|`loginid@fc44:16:1##:####:####::1`|
 
-These addresses will not work if the device cannot reach the Internet. In this case, it can still be accessed by directly connecting a PC or other device to the third (`phy2`) Ethernet port and configuring your system to use the static IP address `100.64.99.94` with netmask `255.255.255.252` (`/30`). The Edge can now be reached via http and ssh at `100.64.99.93`. This IP is always available on the `phy2` port for emergency recovery if you become locked out of the device or it’s configured in a way that breaks Internet connectivity.
+These addresses will not work if the device cannot reach the Internet. In this case, it can still be accessed by directly connecting a PC or other device to the third (`phy2`) Ethernet port and configuring your system to use the static IP address `100.64.99.94` with netmask `255.255.255.252` (`/30`). The Edge can now be reached via http and ssh at `100.64.99.93`. This IP is always available on the `phy2` port for emergency recovery if you become locked out of the device or it's configured in a way that breaks Internet connectivity.
 
 ### Quick Start Guide
 
-- Plug the Edge’s first Ethernet port (`phy0`) into an Ethernet network with IPv4 (DHCP) or IPv6 connectivity.
+- Plug the Edge's first Ethernet port (`phy0`) into an Ethernet network with IPv4 (DHCP) or IPv6 connectivity.
 - Connect the device to power and wait 20-30 seconds.
 - Join the ad-hoc ZeroTier network `ff001601bb000000` from a PC, mobile, or other devices. See <https://www.zerotier.com> to download clients.
 - Once your PC or other device is online, navigate to the http address shown in the green box above.
@@ -37,28 +37,28 @@ These addresses will not work if the device cannot reach the Internet. In this c
 
 :::info IMPORTANT!
 
-The Edge device itself must be designated as an Ethernet bridge on all ZeroTier virtual networks you wish to bridge to physical ports. This must be done via ZeroTier Central, or if you are running your own network controller by setting the “activeBridge” field to “true” in the Edge’s network member record. If the Edge is not authorized to act as a bridge it will not be permitted to forward Ethernet packets to and from devices other than itself.
+The Edge device itself must be designated as an Ethernet bridge on all ZeroTier virtual networks you wish to bridge to physical ports. This must be done via ZeroTier Central, or if you are running your own network controller by setting the "activeBridge" field to "true" in the Edge's network member record. If the Edge is not authorized to act as a bridge it will not be permitted to forward Ethernet packets to and from devices other than itself.
 
-It’s also important to understand bridging. A virtual bridge is exactly like a physical Ethernet cable stretching from point A to point B. Devices on either side will only be able to see one another at the TCP/IP level if they occupy the same IP range(s) or are given routing table entries indicating that they should access bridged IP ranges via the local LAN. This can typically be done by configuring local DHCP servers at each site to hand out appropriate routing information.
+It's also important to understand bridging. A virtual bridge is exactly like a physical Ethernet cable stretching from point A to point B. Devices on either side will only be able to see one another at the TCP/IP level if they occupy the same IP range(s) or are given routing table entries indicating that they should access bridged IP ranges via the local LAN. This can typically be done by configuring local DHCP servers at each site to hand out appropriate routing information.
 :::
 
 #### 1. In-Line Bridge and Wireless Access Point
 
-Connect the Edge’s `phy0` port directly to the Internet (leave its configuration set to defaults) and enter a ZeroTier virtual network for port phy1. Ensure that the checkboxes instructing the Edge to block DHCP, etc., remain unchecked so that DHCP and other auto-configuration packets will be carried across the bridge. Also, ensure that the port is not configured to itself obtain DHCP addresses and act as an uplink port.
+Connect the Edge's `phy0` port directly to the Internet (leave its configuration set to defaults) and enter a ZeroTier virtual network for port phy1. Ensure that the checkboxes instructing the Edge to block DHCP, etc., remain unchecked so that DHCP and other auto-configuration packets will be carried across the bridge. Also, ensure that the port is not configured to itself obtain DHCP addresses and act as an uplink port.
 
-Configure the wireless port for AP mode and enter the same ZeroTier virtual network ID there to allow direct wireless access to the virtual network.  This configuration is typically used in cases when you want to route all traffic through the bridge to a gateway in the cloud. It’s common to set up a cloud node to act as an Internet router and provide DHCP, DHCP6, IPv6-RA, DNS, and other services in this case. Multiple locations, remote users, etc. could all share the same cloud gateway to simultaneously provide enhanced security, privacy, SDWAN, and VPN functionality.
+Configure the wireless port for AP mode and enter the same ZeroTier virtual network ID there to allow direct wireless access to the virtual network.  This configuration is typically used in cases when you want to route all traffic through the bridge to a gateway in the cloud. It's common to set up a cloud node to act as an Internet router and provide DHCP, DHCP6, IPv6-RA, DNS, and other services in this case. Multiple locations, remote users, etc. could all share the same cloud gateway to simultaneously provide enhanced security, privacy, SDWAN, and VPN functionality.
 
-#### 2. Single Port “Magic Bridge”
+#### 2. Single Port "Magic Bridge"
 
-Connect the Edge’s phy0 port to your internal LAN. Configure the Edge to obtain IPv4 and IPv6 addresses via this port, and also enter a ZeroTier address. Be sure to check the three boxes to instruct the Edge to block bridging of DHCP, DHCP6, and IPv6-RA packets to ensure that local DHCP servers do not interfere with servers at other locations.
+Connect the Edge's phy0 port to your internal LAN. Configure the Edge to obtain IPv4 and IPv6 addresses via this port, and also enter a ZeroTier address. Be sure to check the three boxes to instruct the Edge to block bridging of DHCP, DHCP6, and IPv6-RA packets to ensure that local DHCP servers do not interfere with servers at other locations.
 
-Ensure that devices on the virtual network are configured to see the IP address block(s) of your physical LAN as “local.” The Edge will now bridge your local LAN to a virtual ZeroTier network, making remote resources such as cloud servers and remote workers’ laptops appear as if they’re connected to the local LAN. These remote resources should also be able to use local LAN devices like printers, smart TVs, etc.
+Ensure that devices on the virtual network are configured to see the IP address block(s) of your physical LAN as "local." The Edge will now bridge your local LAN to a virtual ZeroTier network, making remote resources such as cloud servers and remote workers' laptops appear as if they're connected to the local LAN. These remote resources should also be able to use local LAN devices like printers, smart TVs, etc.
 
 This configuration is common when users want to provide remote access (replacing conventional VPNs) or join two office LANs together to form a single network while retaining separate Internet connections on either side. In this configuration, normal Internet traffic will use your local internet connection as usual but internal Ethernet traffic will be bridged as if a very long LAN cable were strung from one location to the other.
 
 #### 3. Using Multiple Internet Connections
 
-Multiple Internet connections can be used by simply connecting secondary connections to the Edge’s other Ethernet ports and configuring these ports to obtain addresses via DHCP, DHCP6, etc. Multiple connections can be used with either configuration scenario above. For the second  "magic bridge” scenario, configure the first port as instructed and then connect secondary or “back-up” Internet connections to the remaining ports. These would only be used for ZeroTier bridge traffic in this case.
+Multiple Internet connections can be used by simply connecting secondary connections to the Edge's other Ethernet ports and configuring these ports to obtain addresses via DHCP, DHCP6, etc. Multiple connections can be used with either configuration scenario above. For the second  "magic bridge" scenario, configure the first port as instructed and then connect secondary or "back-up" Internet connections to the remaining ports. These would only be used for ZeroTier bridge traffic in this case.
 
 #### 4. Multiple Internet Connections on One Port (Advanced)
 
@@ -66,7 +66,7 @@ The Edge has only three physical ports but it can be connected to more than thre
 
 ### Advanced Administration
 
-Advanced users can log into the Edge via ssh using the user name and password created with the web UI. The “motd” file printed at login lists a variety of network diagnostic tools that are pre-installed and can be used to probe and debug networks. The “sudo” command is configured to allow these commands to be run as root, but we discourage users from attempting to escape “sudo” or do other things as root since changes to the device’s configuration could be lost on update or could cause problems with the software update procedure.
+Advanced users can log into the Edge via ssh using the user name and password created with the web UI. The "motd" file printed at login lists a variety of network diagnostic tools that are pre-installed and can be used to probe and debug networks. The "sudo" command is configured to allow these commands to be run as root, but we discourage users from attempting to escape "sudo" or do other things as root since changes to the device's configuration could be lost on update or could cause problems with the software update procedure.
 
 ### Factory Reset Procedure
 

--- a/docs/faq-central.md
+++ b/docs/faq-central.md
@@ -11,11 +11,11 @@ Other than that, there is no way to transfer individual networks between account
 
 #### To change your Organization Owner {#change-org-owner}
 
-What you can do is change the email address of your account to a different address. From the account page, select “Manage Account” then “Personal Info”.  From there you can change the email address. After changing, please log out and log back in.
+What you can do is change the email address of your account to a different address. From the account page, select "Manage Account" then "Personal Info".  From there you can change the email address. After changing, please log out and log back in.
 
 Note: This email address must not already have a ZeroTier Central account.
 
-Many users prefer to use something like “billing” or “admin” `@example.com` for their organization owner email account and then invite `alice@example.com` and `bob@example.com` as network admins.
+Many users prefer to use something like "billing" or "admin" `@example.com` for their organization owner email account and then invite `alice@example.com` and `bob@example.com` as network admins.
 
 :::tip
 [See our main FAQ for more topics](./faq.md)

--- a/docs/faq-macos.md
+++ b/docs/faq-macos.md
@@ -5,7 +5,7 @@ description: Guidance for running ZeroTier on macOS
 
 ### Start and Stop ZeroTier on your Mac
 
-The ZeroTier menubar app is a separate process from the system service that makes ZeroTier work. You can quit the menubar app from it’s menu and the system service will continue to run.
+The ZeroTier menubar app is a separate process from the system service that makes ZeroTier work. You can quit the menubar app from it's menu and the system service will continue to run.
 
 To stop/start the ZeroTier system service, open Terminal.app and paste these commands:
 
@@ -32,7 +32,7 @@ If you're [already up and running](./start.md), here's how to share files from y
 Joining a ZeroTier network is like connecting the same WiFi or plugging in to the same Ethernet switch as your other devices, so things mostly "Just Work".
 Many virtual network products do not have this convenient property. ZeroTier works at Layer 2.
 
-#### Look at the Network section of Finder’s sidebar
+#### Look at the Network section of Finder's sidebar
 
 It seems to take a while for Macs to notice each other the first time. Then they start showing up in the Network tab of the Finder.
 

--- a/docs/faq-rules.md
+++ b/docs/faq-rules.md
@@ -9,7 +9,7 @@ Check [the manual](./rules.md) for theory about how rules work.
 
 ### Client Isolation
 
-Do you have a couple server or admin nodes, but you don’t want members to be able to talk to each other?
+Do you have a couple server or admin nodes, but you don't want members to be able to talk to each other?
 
 ```sh
 tag server
@@ -23,7 +23,7 @@ break not tor server 1;
 
 # This is required because the default action is 'drop'.
 accept;
-See the "Tags Matrix" in the section below after saving the rules. Set your servers to “Yes”
+See the "Tags Matrix" in the section below after saving the rules. Set your servers to "Yes"
 ```
 
 ### Block all traffic on ZeroTier network
@@ -49,8 +49,8 @@ drop chr tcp_syn and not chr tcp_ack; # No new TCP connections (except RDP)
 accept; # Accept what's left, returning RDP traffic
 ```
 
-This is a common request, but we’re not sure this is best pattern for rules. See the manual and the other examples in the wiki.
+This is a common request, but we're not sure this is best pattern for rules. See the manual and the other examples in the wiki.
 
-In particular, this has the disadvantage of blocking RDP’s UDP mode.
+In particular, this has the disadvantage of blocking RDP's UDP mode.
 
 Locking down UDP

--- a/docs/faq-windows.md
+++ b/docs/faq-windows.md
@@ -5,7 +5,7 @@ description: Guidance for running ZeroTier on Windows
 
 ### Installing ZeroTier over Windows Remote Desktop
 
-Using the graphical ZeroTier installer won’t work in an RDP session.
+Using the graphical ZeroTier installer won't work in an RDP session.
 
 There is a command-line workaround, open a PowerShell with Administrative Privileges and paste:
 
@@ -13,7 +13,7 @@ There is a command-line workaround, open a PowerShell with Administrative Privil
 msiexec /i "C:\Path\To\ZeroTier One.msi"
 ```
 
-Try the msiexec’s silent install options too.
+Try the msiexec's silent install options too.
 
 ### Windows Remote Desktop Disconnects
 
@@ -31,7 +31,7 @@ See this superuser post for more options and info
 
 #### Lower RDP Experience Settings
 
-If the purpose of your ZeroTier network is solely remoting into office workstations, don’t miss our example rule sets
+If the purpose of your ZeroTier network is solely remoting into office workstations, don't miss our example rule sets
 
 :::tip See Also
 [Client Isolation Rules](./faq-rules.md#client-isolation) and [RDP Only Rules](./faq-rules.md#remote-desktop-only-rdp-only)
@@ -55,13 +55,13 @@ Windows may show the ZeroTier virtual network port as a 100mbps or 10mbps port. 
 
 ### General Troubleshooting
 
-If you’re having trouble using ZeroTier on Windows, the following steps may be of assistance.
+If you're having trouble using ZeroTier on Windows, the following steps may be of assistance.
 
 #### Instructions
 
 - Make sure you have Administrative Rights on your user.
 - Uninstall any other VPN software that could be conflicting with the ZeroTier setup.
-- Check for any antivirus software that has additional “Internet Security” features, that could be blocking installation and trying to assume Windows Firewall functionality.
+- Check for any antivirus software that has additional "Internet Security" features, that could be blocking installation and trying to assume Windows Firewall functionality.
 - Try different combinations of rebooting and reinstalling ZeroTier.
 
 Side note: there were reported VPN issues in certain versions of Windows 10; those have their own fix via Microsoft.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,7 +34,7 @@ No. Your traffic is end-to-end encrypted and your device's private identity keys
 The nodes are usually our infrastructure that your node needs to talk to in order to function. This includes things like: [Root servers](roots) and [Controllers](controller). Or possibly nodes from a previously joined network. The command `zerotier-cli peers` shows a list of nodes that your node knows about. Nodes can not talk to each other unless they are joined and authorized on the same network. Our root servers and controllers do not have access to you nodes' encryption keys and thus cannot decrypt your traffic.
 
 :::info How to identify a controller
-A controller is a ZeroTier node. The first 10 digits of a Network ID is the controller’s address.
+A controller is a ZeroTier node. The first 10 digits of a Network ID is the controller's address.
 :::
 
 ### What is error `NOT_FOUND`? {#notfound}
@@ -82,7 +82,7 @@ This error means that the ZeroTier background service on your computer is either
 
 ### Windows 10
 
-Open Task Manager and go to the “Services” tab. Scroll down until you see `ZeroTierOneService`. The status column should say `Running`. If it does not, right click on the line and click `Start`
+Open Task Manager and go to the "Services" tab. Scroll down until you see `ZeroTierOneService`. The status column should say `Running`. If it does not, right click on the line and click `Start`
 
 ### macOS
 
@@ -99,7 +99,7 @@ If your Linux distribution uses systemd, execute `sudo service zerotier-one star
 
 If not, execute `sudo /etc/init.d/zerotier-one start`
 
-### Still doesn’t work?
+### Still doesn't work?
 
 Your system firewall is likely blocking communication with the ZeroTier service. Look up instructions for how to unblock an application from the firewall for your OS.  ZeroTier will need to be accessible via TCP port 9993 for the UI and CLI to interact with it.
 

--- a/docs/network-leave.md
+++ b/docs/network-leave.md
@@ -3,7 +3,7 @@ title: Leave Network
 description: Removing your node from a ZeroTier virtual network
 ---
 
-When you leave a network, your device won’t talk to devices on that network.
+When you leave a network, your device won't talk to devices on that network.
 
 ### macOS and Windows
 

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -3,7 +3,7 @@ title: Organizations
 description: How to use ZeroTier Organizations
 ---
 
-You’ve subscribed to my.zerotier.com and want your coworkers to also have the benefits of a Pro account.
+You've subscribed to my.zerotier.com and want your coworkers to also have the benefits of a Pro account.
 
 Add them to your Organization by going to my.zerotier.com/account
 
@@ -25,10 +25,10 @@ The invited User will see:
 
 ### Removing Admins from the Organization
 
-You can click the “remove” button next to their name in the list of admins. They will lose Admin access to the organizations networks.
+You can click the "remove" button next to their name in the list of admins. They will lose Admin access to the organizations networks.
 
 ### Change the Organization owner
 
-Consider using a general email address like “<billing@example.com>” when you sign up.
+Consider using a general email address like "<billing@example.com>" when you sign up.
 
 Can I move or transfer my network(s) to another user?

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -7,9 +7,9 @@ description: Common pricing questions
 See our [pricing page](https://www.zerotier.com/pricing/) for current plans.
 :::
 
-### Do my networks still work properly if I’m out of compliance?
+### Do my networks still work properly if I'm out of compliance?
 
-Yes, everything works fine for the old network members you’ve set up. Many people use ZeroTier for critical infrastructure and we make it our highest priority to ensure your service isn't interrupted in relation to the new pricing plan. Our enforcement just blocks your ability to add new members to your network until you’re in compliance with the new plan.
+Yes, everything works fine for the old network members you've set up. Many people use ZeroTier for critical infrastructure and we make it our highest priority to ensure your service isn't interrupted in relation to the new pricing plan. Our enforcement just blocks your ability to add new members to your network until you're in compliance with the new plan.
 
 :::info Historical
 On Thursday, 9 June 2022 we updated our product plans and the Free Basic plan has changed. Here are some things to know:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -41,7 +41,7 @@ The ZeroTier protocol is original, though aspects of it are similar to
 VXLAN and IPSec. It has two conceptually separate but closely coupled
 layers [in the OSI model](https://en.wikipedia.org/wiki/OSI_model)
 sense: **VL1** and **VL2**. VL1 is the underlying peer to peer transport
-layer, the “virtual wire,” while VL2 is an emulated Ethernet layer that
+layer, the "virtual wire," while VL2 is an emulated Ethernet layer that
 provides operating systems and apps with a familiar communication
 medium.
 
@@ -60,7 +60,7 @@ on a dynamic as-needed basis.
 
 VL1 is designed to be zero-configuration. A user can start a new
 ZeroTier node without having to write configuration files or provide the
-IP addresses of other nodes. It’s also designed to be fast. Any two
+IP addresses of other nodes. It's also designed to be fast. Any two
 devices in the world should be able to locate each other and communicate
 almost instantly.
 
@@ -72,16 +72,16 @@ same software as regular endpoints but reside at fast stable locations
 on the network and are designated as such by a **world definition**.
 World definitions come in two forms: the **planet** and one or more
 **moons**. The protocol includes a secure mechanism allowing world
-definitions to be updated in-band if root servers’ IP addresses or
+definitions to be updated in-band if root servers' IP addresses or
 ZeroTier addresses change.
 
-There is only one planet. Earth’s root servers are operated by ZeroTier,
+There is only one planet. Earth's root servers are operated by ZeroTier,
 Inc. as a free service. There are currently twelve root servers
 organized into two six-member clusters distributed across every major
 continent and multiple network providers. Almost everyone in the world
 has one within less than 100ms network latency from their location.
 
-A node can “orbit” any number of moons. A moon is just a convenient way
+A node can "orbit" any number of moons. A moon is just a convenient way
 to add user-defined root servers to the pool. Users can create moons to
 reduce dependency on ZeroTier, Inc. infrastructure or to locate root
 servers closer for better performance. For on-premise SDN use a cluster
@@ -93,9 +93,9 @@ Nodes start with no direct links to one another, only upstream to roots
 (planet and moons). Every peer on VL1 possesses a globally unique 40-bit
 (10 hex digit) **ZeroTier address**, but unlike IP addresses these are
 opaque cryptographic identifiers that encode no routing information. To
-communicate peers first send packets “up” the tree, and as these packets
+communicate peers first send packets "up" the tree, and as these packets
 traverse the network they trigger the opportunistic creation of direct
-links along the way. The tree is constantly trying to “collapse itself”
+links along the way. The tree is constantly trying to "collapse itself"
 to optimize itself to the pattern of traffic it is carrying.
 
 Peer to peer connection setup goes like this:
@@ -119,11 +119,11 @@ Peer to peer connection setup goes like this:
 Since roots forward packets, A and B can reach each other instantly. A
 and B then begin attempting to make a direct peer to peer connection. If
 this succeeds it results in a faster lower latency link. We call this
-*transport triggered link provisioning* since it’s the forwarding of the
+*transport triggered link provisioning* since it's the forwarding of the
 packet itself that triggers the peer to peer network to attempt direct
 connection.
 
-VL1 never gives up. If a direct path can’t be established, communication
+VL1 never gives up. If a direct path can't be established, communication
 can continue through (slower) relaying. Direct connection attempts
 continue forever on a periodic basis. VL1 also has other features for
 establishing direct connectivity including LAN peer discovery, port
@@ -131,24 +131,24 @@ prediction for traversal of symmetric IPv4 NATs, and explicit port
 mapping using uPnP and/or NAT-PMP if these are available on the local
 physical LAN.
 
-*[A blog post from 2014 by ZeroTier’s original author explains some of
-the reasoning behind VL1’s
+*[A blog post from 2014 by ZeroTier's original author explains some of
+the reasoning behind VL1's
 design.](http://adamierymenko.com/decentralization.html)*
 
 ### Addressing {#addressing}
 
 Every node is uniquely identified on VL1 by a 40-bit (10 hex digit)
 **ZeroTier address**. This address is computed from the public portion
-of a public/private key pair. A node’s address, public key, and private
+of a public/private key pair. A node's address, public key, and private
 key together form its **identity**.
 
 *On devices running ZeroTier One the node identity is stored in
-`identity.public` and `identity.secret` in the service’s home
+`identity.public` and `identity.secret` in the service's home
 directory.*
 
 When ZeroTier starts for the first time it generates a new identity. It
 then attempts to advertise it upstream to the network. In the very
-unlikely event that the identity’s 40-bit unique address is taken, it
+unlikely event that the identity's 40-bit unique address is taken, it
 discards it and generates another.
 
 Identities are claimed on a first come first serve basis and currently
@@ -160,7 +160,7 @@ The address derivation algorithm used to compute addresses from public
 keys imposes a computational cost barrier against the intentional
 generation of a collision. Currently it would take approximately 10,000
 CPU-years to do so (assuming e.g. a 3ghz Intel core). This is expensive
-but not impossible, but it’s only the first line of defense. After
+but not impossible, but it's only the first line of defense. After
 generating a collision an attacker would then have to compromise all
 upstream nodes, network controllers, and anything else that has recently
 communicated with the target node and replace their cached identities.
@@ -174,8 +174,8 @@ an authoritative identity cache.
 
 ### Cryptography {#cryptography}
 
-If you don’t know much about cryptography you can safely skip this
-section. **TL;DR: packets are end-to-end encrypted and can’t be read by
+If you don't know much about cryptography you can safely skip this
+section. **TL;DR: packets are end-to-end encrypted and can't be read by
 roots or anyone else, and we use modern 256-bit crypto in ways
 recommended by the professional cryptographers that created it.**
 
@@ -195,7 +195,7 @@ implementation](https://nacl.cr.yp.to/).
 
 As of today we do not implement [forward
 secrecy](https://en.wikipedia.org/wiki/Forward_secrecy) or other
-stateful cryptographic features in VL1. We don’t do this for the sake of
+stateful cryptographic features in VL1. We don't do this for the sake of
 simplicity, reliability, and code footprint, and because frequently
 changing state makes features like clustering and fail-over much harder
 to implement. See [our discussion on
@@ -207,7 +207,7 @@ protocols such as SSL or SSH over ZeroTier. These protocols typically
 implement forward secrecy, but using them over ZeroTier also provides
 the secondary benefit of defense in depth. Most cryptography is
 compromised not by a flaw in encryption but through bugs in the
-implementation. If you’re using two secure transports, the odds of a
+implementation. If you're using two secure transports, the odds of a
 critical bug being discovered in both at the same time is very low. The
 CPU overhead of double-encryption is not significant for most work
 loads.
@@ -229,12 +229,12 @@ security.
 Trusted paths do not prevent communication with devices elsewhere, since
 traffic over other paths will be encrypted and authenticated normally.
 
-We don’t recommend the use of this feature unless you really need the
-performance and you know what you’re doing. We also recommend thinking
+We don't recommend the use of this feature unless you really need the
+performance and you know what you're doing. We also recommend thinking
 carefully before disabling transport security on a cloud private
 network. Larger cloud providers such as Amazon and Azure tend to provide
 good network segregation but many less costly providers offer private
-networks that are “party lines” and are not much more secure than the
+networks that are "party lines" and are not much more secure than the
 open Internet.
 
 ### Multipath {#multipath}
@@ -254,11 +254,11 @@ network virtualization protocol with SDN management features. It
 implements secure VLAN boundaries, multicast, rules, capability based
 security, and certificate based access control.
 
-VL2 is built atop and carried by VL1, and in so doing it inherits VL1’s
+VL2 is built atop and carried by VL1, and in so doing it inherits VL1's
 encryption and endpoint authentication and can use VL1 asymmetric keys
 to sign and verify credentials. VL1 also allows us to implement VL2
 entirely free of concern for underlying physical network topology.
-Connectivity and routing efficiency issues are VL1 concerns. It’s
+Connectivity and routing efficiency issues are VL1 concerns. It's
 important to understand that there is no relationship between VL2
 virtual networks and VL1 paths. Much like VLAN multiplexing on a wired
 LAN, two nodes that share multiple network memberships in common will
@@ -268,7 +268,7 @@ still only have one VL1 path (virtual wire) between them.
 
 Each VL2 network (VLAN) is identified by a 64-bit (16 hex digit)
 **ZeroTier network ID** that contains the 40-bit ZeroTier address of the
-network’s **controller** and a 24-bit number identifying the network on
+network's **controller** and a 24-bit number identifying the network on
 the controller.
 
     Network ID: 8056c2e21c123456
@@ -278,8 +278,8 @@ the controller.
                 ZeroTier address of controller
 
 When a node joins a network or requests a network configuration update,
-it sends a network config query message (via VL1) to the network’s
-controller. The controller can then use the node’s VL1 address to look
+it sends a network config query message (via VL1) to the network's
+controller. The controller can then use the node's VL1 address to look
 it up on the network and send it the appropriate certificates,
 credentials, and configuration information. From the perspective of VL2
 virtual networks, VL1 ZeroTier addresses can be thought of as port
@@ -289,21 +289,21 @@ A common misunderstanding is to conflate network controllers with root
 servers (planet and moons). Root servers are connection facilitators
 that operate at the VL1 level. Network controllers are configuration
 managers and certificate authorities that belong to VL2. Generally root
-servers don’t join or control virtual networks and network controllers
+servers don't join or control virtual networks and network controllers
 are not root servers, though it is possible to have a node do both.
 
 #### Controller Security Considerations {#controllersecurityconsiderations}
 
 Network controllers serve as certificate authorities for ZeroTier
 virtual networks. As such, their `identity.secret` files should be
-guarded closely and backed up securely. Compromise of a controller’s
+guarded closely and backed up securely. Compromise of a controller's
 secret key would allow an attacker to issue fraudulent network
 configurations or admit unauthorized members, while loss of the secret
 key results in loss of ability to control the network in any way or
 issue configuration updates and effectively renders the network
 unusable.
 
-It is important that controllers’ system clocks remain relatively
+It is important that controllers' system clocks remain relatively
 accurate (to within 30-60 seconds) and that they are secure against
 remote tampering. Many cloud providers provide secure time sources
 either directly via the hypervisor or via NTP servers within their
@@ -312,10 +312,10 @@ networks.
 ### Certificates and Other Credentials {#certificates}
 
 All credentials issued by network controllers to member nodes in a given
-network are signed by the controller’s secret key to allow all network
+network are signed by the controller's secret key to allow all network
 members to verify them. Credentials have timestamp fields populated by
 the controller, allowing relative comparison without the need to trust
-the node’s local system clock.
+the node's local system clock.
 
 Credentials are issued only to their owners and are then pushed peer to
 peer by nodes that wish to communicate with other nodes on the network.
@@ -328,9 +328,9 @@ controller.
 - **Certificates of Membership**: a certificate that a node presents
     to obtain the right to communicate on a given network. Certificates
     of membership are accepted if they *agree*, meaning that the
-    submitting member’s certificate’s timestamp differs from the
-    recipient’s certificate’s timestamp by no more than the recipient
-    certificate’s maximum timestamp delta value. This creates a
+    submitting member's certificate's timestamp differs from the
+    recipient's certificate's timestamp by no more than the recipient
+    certificate's maximum timestamp delta value. This creates a
     decentralized moving-window scheme for certificate expiration
     without requiring node clock synchronization or constant checking
     with the controller.
@@ -343,7 +343,7 @@ controller.
 - **Capabilities**: a capability is a bundle of network rules that is
     signed by the controller and can be presented to other members of a
     network to grant the presenter elevated privileges within the
-    framework of the network’s base rule set. More on this in the
+    framework of the network's base rule set. More on this in the
     section on rules.
 - **Tags**: a tag is a key/value pair signed by the controller that is
     automatically presented by members to one another and can be matched
@@ -388,7 +388,7 @@ significant bandwidth overhead.
 
 IPv4 [ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol) is
 built on simple Ethernet broadcast and scales poorly on large or
-distributed networks. To improve ARP’s scalability ZeroTier generates a
+distributed networks. To improve ARP's scalability ZeroTier generates a
 unique multicast group for each IPv4 address detected on its system and
 then transparently intercepts ARP queries and sends them only to the
 correct group. This converts ARP into effectively a unicast or narrow
@@ -413,9 +413,9 @@ hundreds of milliseconds over a wide area network, or more if latencies
 associated with pub/sub recipient lookup are significant.
 
 IPv6 addresses are large enough to easily encode ZeroTier addresses. For
-faster operation and better scaling we’ve implemented several special
+faster operation and better scaling we've implemented several special
 IPv6 addressing modes that allow the local node to emulate NDP. These
-are ZeroTier’s **rfc4193** and **6plane** IPv6 address assignment
+are ZeroTier's **rfc4193** and **6plane** IPv6 address assignment
 schemes. If these addressing schemes are enabled on a network, nodes
 locally intercept outbound NDP queries for matching addresses and then
 locally generate spoofed NDP replies.
@@ -467,17 +467,17 @@ See our [bridging tutorial](bridging)
 ### Public Networks {#public}
 
 It is possible to disable access control on a ZeroTier network. A public
-network’s members do not check certificates of membership, and new
+network's members do not check certificates of membership, and new
 members to a public network are automatically marked as authorized by
 their host controller. It is not possible to de-authorize a member from
 a public network.
 
-Rules on the other hand *are* enforced, so it’s possible to implement a
+Rules on the other hand *are* enforced, so it's possible to implement a
 special purpose public network that only allows access to a few things
 or that only allows a restricted subset of traffic.
 
-Public networks are useful for testing and for peer to peer “party
-lines” for gaming, chat, and other applications. **Participants in public
+Public networks are useful for testing and for peer to peer "party
+lines" for gaming, chat, and other applications. **Participants in public
 networks are warned to pay special attention to security. If joining a
 public network be careful not to expose vulnerable services or
 accidentally share private files via open network shares or HTTP

--- a/docs/roots.md
+++ b/docs/roots.md
@@ -10,21 +10,21 @@ on a planet effectively inhabit a single data center. This makes it easy
 to directly connect devices anywhere, but it has the disadvantage of not
 working without an Internet connection. Network connections are far from
 perfectly reliable, and sometimes for security reasons a user may wish
-to “air gap” a set of nodes from the rest of the Internet entirely.
+to "air gap" a set of nodes from the rest of the Internet entirely.
 
 In 1.2.0 we introduced the ability to add your own user-defined roots.
 Since the data center we inhabit is the planet, a user-defined set of
-roots is called a **moon**. When a node “orbits” a moon, it adds the
-moon’s roots to its root server set. Nodes orbiting moons will still use
-planetary roots, but they’ll use the moon’s roots if they look faster or
+roots is called a **moon**. When a node "orbits" a moon, it adds the
+moon's roots to its root server set. Nodes orbiting moons will still use
+planetary roots, but they'll use the moon's roots if they look faster or
 if nothing else is available.
 
 The first step in creating a moon is to deploy a set of root servers. In
 most cases we recommend two. These are regular ZeroTier nodes, but ones
 that are always on and have static (physical) IP addresses. These static
 IPs could be global Internet IPs or physical intranet IPs that are only
-reachable internally. In the latter case your moon’s roots won’t work
-outside your office, but that doesn’t matter. Roaming nodes will just
+reachable internally. In the latter case your moon's roots won't work
+outside your office, but that doesn't matter. Roaming nodes will just
 use planetary roots instead.
 
 We recommend that root servers do not act as network controllers, join
@@ -38,7 +38,7 @@ two.
 
 The next step is to create a world definition using `zerotier-idtool`.
 You will need the `identity.public` files from each of your root
-servers. Pick one root (doesn’t matter which) and run
+servers. Pick one root (doesn't matter which) and run
 `zerotier-idtool initmoon <identity.public of one root> >>moon.json`.
 The `zerotier-idtool`command will output a JSON version of your world
 definition to *stdout*, so we redirect it to `moon.json`.
@@ -66,11 +66,11 @@ Examine this file. It will contain something like:
 The world ID is technically arbitrary and could be any random 64-bit
 value. By convention we use the address of one of the roots.
 
-The world definition JSON file **contains secrets**, so it’s important
+The world definition JSON file **contains secrets**, so it's important
 to keep it in a safe place. The `signingKey_SECRET` is what will allow
 you to update your world definition automatically in the future.
 
-Now add your other root(s) and define their stable endpoints. You’ll end
+Now add your other root(s) and define their stable endpoints. You'll end
 up with something that looks like:
 
 ```json
@@ -95,7 +95,7 @@ up with something that looks like:
 ```
 
 The static IP addresses you use must be reachable from all the places
-you want these roots to serve. If you’re deploying these for use at a
+you want these roots to serve. If you're deploying these for use at a
 physical location, use internal IPs. If you want them to be usable
 off-site, use public IPs from your DMZ or host them at a cloud provider
 with a data center presence close to you. Low-cost cloud hosts that
@@ -121,9 +121,9 @@ using the `zerotier-cli orbit` command:
 `zerotier-cli orbit deadbeef00 deadbeef00`. The first argument is the
 world ID (which we can shorten by removing the two leading zeroes) and
 the second is the address of any of its roots. This will contact the
-root and obtain the full world definition from it if it’s online and
+root and obtain the full world definition from it if it's online and
 reachable.
 
-Once you’ve “orbited” your moon, try `zerotier-cli listpeers`. You
-should see the roots you’ve created listed as `MOON` instead of `LEAF`.
+Once you've "orbited" your moon, try `zerotier-cli listpeers`. You
+should see the roots you've created listed as `MOON` instead of `LEAF`.
 They will now be used as alternative root servers.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,7 +12,7 @@ compromise both sides of any conversation.
 The ZeroTier VL2 rules engine differs from most other firewalls and SDN
 rules engines in several ways. The most immediately relevant of these is
 that the ZeroTier rules engine is stateless, meaning it lacks connection
-tracking. This means that bidirectional whitelisting can’t be
+tracking. This means that bidirectional whitelisting can't be
 accomplished by simply whitelisting reply packets to established
 connections. Instead some thought must be put into how to allow both
 sides of a desired flow. Rule patterns to achieve the most common
@@ -38,8 +38,8 @@ conceptual way that is both easier for human beings to understand and
 more efficient for machines to handle.
 
 This section assumes some level of familiarity with network rules as
-they’re commonly used on firewalls and routers, etc. While the rules
-engine is part of VL2, it’s been given its own section in this manual
+they're commonly used on firewalls and routers, etc. While the rules
+engine is part of VL2, it's been given its own section in this manual
 due to the depth and cross-cutting nature of the topic.
 
 ### Rule Sets and Rule Evaluation
@@ -54,9 +54,9 @@ permissive actions are taken by any rule set the packet is discarded.
 
 Here is a simple rule set that constrains Ethernet traffic on a network
 to only IPv4, ARP, or IPv6 as it would appear in the raw JSON format
-used by ZeroTier One’s built-in network controller implementation.
-(Don’t worry if this seems verbose and difficult. We have a more
-human-friendly way of writing rule sets, but before we introduce it it’s
+used by ZeroTier One's built-in network controller implementation.
+(Don't worry if this seems verbose and difficult. We have a more
+human-friendly way of writing rule sets, but before we introduce it it's
 important to understand what is really happening.)
 
 ```json
@@ -97,9 +97,9 @@ none of these) then the **drop** action is taken. Otherwise the
 Networks have one base rule set that is applied to all traffic. Its size
 is constrained to 1024 entries (each match or action is an entry). It
 should be used to set the overall policies for all members of the
-network, and for most common use cases it’s all you’ll need. For more
+network, and for most common use cases it's all you'll need. For more
 complex scenarios, both capabilities and tags provide methods of both
-managing complexity and scaling the overall size of a network’s rule
+managing complexity and scaling the overall size of a network's rule
 system.
 
 ### Actions and Match Conditions {#311actionsandmatchconditionsaname3_1_1a}
@@ -139,8 +139,8 @@ way for human beings to specify rules.
 | MATCH\_TAGS\_BITWISE\_OR | id,value | Tags ORed together equal value. |
 | MATCH\_TAGS\_BITWISE\_XOR | id,value | Tags XORed together equal value. |
 | MATCH\_TAGS\_EQUAL | id,value | Both tags equal the same value. |
-| MATCH\_TAG\_SENDER | id,value | Sending side’s tag equals this value. |
-| MATCH\_TAG\_RECEIVER | id,value | Receiving side’s tag equals this value. |
+| MATCH\_TAG\_SENDER | id,value | Sending side's tag equals this value. |
+| MATCH\_TAG\_RECEIVER | id,value | Receiving side's tag equals this value. |
 
 ### Capabilities {#32capabilitiesaname3_2a}
 
@@ -156,8 +156,8 @@ match.
 When the recipient receives the capability it authenticates it by
 checking its signature and timestamp and, provided the capability is
 valid, adds it to the set of capabilities to apply to incoming traffic
-from the capability’s owner. The sender has effectively told the
-recipient “I can too send this packet! Teacher says so!”
+from the capability's owner. The sender has effectively told the
+recipient "I can too send this packet! Teacher says so!"
 
 Capabilities allow large systems of rules to be broken down into
 functional aspects and then distributed intelligently only to those
@@ -201,7 +201,7 @@ we place the above tiny rule set into a capability and issue it to a
 device, this device *but no others* will now be permitted to send
 wake-on-LAN magic packets. (Wake-on-LAN requires hardware support so it
 would only work to target devices plugged into a physical network
-bridged to a ZeroTier network, but don’t worry about that here. It’s
+bridged to a ZeroTier network, but don't worry about that here. It's
 just an example of special traffic.)
 
 Capability rule sets are limited to only 64 entries. The idea is to keep
@@ -221,16 +221,16 @@ members by member classification. They allow very detailed network
 micro-segmentation by member role, permission, function, etc. without
 resulting in a combinatorial explosion in rules table size.
 
-Let’s say we want to permit traffic on TCP ports 139 and 445
+Let's say we want to permit traffic on TCP ports 139 and 445
 (netbios/CIFS file sharing) only between systems that belong to the same
 department. Our company has 12,000 devices and 10 departments. Without
 tags this would require 144,000,000 rules, but with tags it can be
 accomplished by only a few.
 
-First a tag is created to represent the department. Let’s give it tag ID
+First a tag is created to represent the department. Let's give it tag ID
 100. Each member system receives the tag with a value from 1 to 10
 indicating which department it belongs to. We can then add the following
-rules to our network’s base rule set (or to a capability if so desired):
+rules to our network's base rule set (or to a capability if so desired):
 
 ```json
 [
@@ -286,14 +286,14 @@ practice, use `default 0` in your tag definitions.
 ### Rule Definition Language {#34ruledefinitionlanguageaname3_4a}
 
 Raw rule sets are verbose and difficult to write, so we created a
-minimal rule definition language that’s easier for human beings.
+minimal rule definition language that's easier for human beings.
 
 The parser for this language can be found in the [rule-compiler
 subfolder of the ZeroTierOne
 project](https://github.com/zerotier/ZeroTierOne/tree/master/rule-compiler)
 and as
 [zerotier-rule-compiler](https://www.npmjs.com/package/zerotier-rule-compiler)
-on NPM. It’s written in JavaScript and is the same code that powers the
+on NPM. It's written in JavaScript and is the same code that powers the
 in-browser editor in ZeroTier Central.
 
 ### An Introductory Example {#341anintroductoryexampleaname3_4_1a}
@@ -467,8 +467,8 @@ Central to make it easier to assign and search tags.
 | tor | <id\> <value\> | Tags ORed together equal value. |
 | txor | <id\> <value\> | Tags XORed together equal value. |
 | teq | <id\> <value\> | Both tags equal the same value. |
-| tseq | <id\> <value\> | Sending side’s tag equals this value. |
-| treq | <id\> <value\> | Receiving side’s tag equals this value. |
+| tseq | <id\> <value\> | Sending side's tag equals this value. |
+| treq | <id\> <value\> | Receiving side's tag equals this value. |
 
 Match conditions may be joined by **and** (default if none specified) or
 **or** and may be modified by **not**.
@@ -523,7 +523,7 @@ TCP packets with permitted destination ports:
     # Allow TCP port 80 (HTTP)
     accept ipprotocol tcp and dport 80;
 
-ZeroTier’s filter is stateless. If we block all TCP packets except those
+ZeroTier's filter is stateless. If we block all TCP packets except those
 with the correct destination port, this will prevent reply packets from
 returning to their senders.
 
@@ -538,7 +538,7 @@ connections cannot be opened unless they are permitted.
 
 ### Locking Down UDP {#352lockingdownudpaname3_5_2a}
 
-UDP is tougher to deal with in a stateless paradigm. It’s connectionless
+UDP is tougher to deal with in a stateless paradigm. It's connectionless
 so there is no way to specifically select a new session vs. an existing
 session. The best way to lock down UDP on a network is to use tags to
 allow it to and from things like DNS servers that need to speak it.
@@ -559,7 +559,7 @@ break ipprotocol udp;
 ```
 
 First we define a tag called `udpserver` with a default value of 0. We
-don’t set any enums or flags for this tag since it will be used as a
+don't set any enums or flags for this tag since it will be used as a
 boolean. For servers that need to respond to DNS queries, set the
 `udpserver` to `1`.
 
@@ -571,12 +571,12 @@ horizontal UDP traffic.
 
 ### Traffic Observation and Interception {#353trafficobservationandinterceptionaname3_5_3a}
 
-Here’s a simple rule to monitor everything:
+Here's a simple rule to monitor everything:
 
     # Send a copy of EVERY packet on both sender and receiver side to ZeroTier address "deadbeef11".
     tee -1 deadbeef11;
 
-That’s going to flood `deadbeef11` with two full copies of every single
+That's going to flood `deadbeef11` with two full copies of every single
 packet, since it will match on both the sender and the recipient side. A
 less bandwidth-intensive security monitor setup might look like this:
 
@@ -600,7 +600,7 @@ ten. The first 128 bytes of a packet will be enough to see the Ethernet
 and IP headers as well as layer 4+ information about many protocols.
 
 This would allow observers to watch every new TCP connection on the
-network and also passively monitor other traffic in a “fuzzy”
+network and also passively monitor other traffic in a "fuzzy"
 probabilistic fashion without using very much bandwidth. We split
 sending and receiving observers to prevent duplicate packets and also to
 allow us to detect cases where one side is failing to tee traffic more
@@ -668,7 +668,7 @@ follows:
       and tand clearance 0
     ;
 
-Initially members will be assigned a default classification of 0 (“no”).
+Initially members will be assigned a default classification of 0 ("no").
 These can freely communicate since the bitwise OR of their *classified*
 tags will be zero. Neither member possesses a classification
 requirement.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ This error means that the ZeroTier background service on your computer is either
 
 ### Windows 10
 
-Open Task Manager and go to the “Services” tab.  Scroll down until you see “ZeroTierOneService”. The status column should say “Running”.  If it does not, right click on the line and click “Start”
+Open Task Manager and go to the "Services" tab.  Scroll down until you see "ZeroTierOneService". The status column should say "Running".  If it does not, right click on the line and click "Start"
 
 ### macOS
 

--- a/docs/windows-unknown-node-id.md
+++ b/docs/windows-unknown-node-id.md
@@ -3,10 +3,10 @@ title: Unknown Node ID
 description: Unknown Node ID
 ---
 
-Is the Windows ZeroTier tray app saying “Unknown” for the Node ID? That means the ZeroTier One system service isn’t running for some reason. Here’s how to turn it back on.
+Is the Windows ZeroTier tray app saying "Unknown" for the Node ID? That means the ZeroTier One system service isn't running for some reason. Here's how to turn it back on.
 
 - Open the Start Menu
-- Start typing “services”
+- Start typing "services"
 - Open Services (desktop app)
 - Find ZeroTier One at the bottom of the list
 - Start it
@@ -19,4 +19,4 @@ Is the Windows ZeroTier tray app saying “Unknown” for the Node ID? That mean
 
 ![screenshot](./images/windows-unknown-nodeid-04.png)
 
-If for some reason the tray app still can’t connect, you can still manage your device’s joined networks with, see: [CLI Help](./cli.md)
+If for some reason the tray app still can't connect, you can still manage your device's joined networks with, see: [CLI Help](./cli.md)


### PR DESCRIPTION
That is:
U+2019 (Right Single Quotation Mark) -> U+0027 (Apostrophe) U+201c (Left Double Quotation Mark) -> U+0022 (Quotation Mark) U+201d (Right Double Quotation Mark) -> U+0022 (Quotation Mark)

I left curly quotes in places where they were copied from somewhere else, such as titles for links.