### PR TITLE
feat: upgrade zerotier-one api docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,6 +179,10 @@ module.exports = {
             route: "/service/v1",
             spec: "./static/openapi/servicev1.json",
           },
+          {
+            route: "/service/preview",
+            spec: "https://github.com/zerotier/zerotier-one-api-spec/releases/latest/download/openapi.yaml"
+          },
         ],
         theme: {
           primaryColor: "#FFB354",


### PR DESCRIPTION
we generate them in a different repo from a typespec. pull them in from there to generate the doc page.

this will put them at https://docs.zerotier.com/service/preview for now 