### PR TITLE
remove explicit links to docs.zerotier.com in favor of local URLs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,7 +35,7 @@ ZeroTier Inc doesn't have access to your traffic. We don't currently supply a mo
 
 - [Prometheus Metrics](https://github.com/zerotier/ZeroTierOne#prometheus-metrics) for the zerotier-one agent are available. Pipe these into the common prometheus/grafana setup.
 - Use your preferred monitoring tool _over_ your ZeroTier networks. Some examples: Prometheus [Blackbox exporter](https://github.com/prometheus/blackbox_exporter), [SmokePing](https://oss.oetiker.ch/smokeping/), [UptimeKuma](https://uptime.kuma.pet/)
-- [Traffic Observation and Interception](https://docs.zerotier.com/rules#353trafficobservationandinterceptionaname3_5_3a)
+- [Traffic Observation and Interception](/rules#353trafficobservationandinterceptionaname3_5_3a)
 
 ### Why does my peers list have nodes I don't recognize? {#unknown-peers}
 

--- a/docs/openwrt.md
+++ b/docs/openwrt.md
@@ -16,7 +16,7 @@ As noted in the wiki article above, you can set a number of basic ZeroTierOne se
 However, some features require manual configuration:
 
 - Hosting a ZeroTier controller on your OpenWRT device requires a writable filesystem location to store controller state (such as authorized members) using the `config_path` option
-- Overriding options in [local.conf](https://docs.zerotier.com/config#local-configuration-options) such as [`lowBandwidthMode`](https://docs.zerotier.com/lbm) requires creating a valid local config file and then setting `local_conf` in the UCI configuration to point to it.
+- Overriding options in [local.conf](/config#local-configuration-options) such as [`lowBandwidthMode`](/lbm) requires creating a valid local config file and then setting `local_conf` in the UCI configuration to point to it.
 
 :::tip Next steps
 Click [here](/start/) to create your network and start adding devices.

--- a/docs/sockets.md
+++ b/docs/sockets.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Encrypted P2P connections for your app or service.
 
-This guide explains how to use the ZeroTier SDK Socket API. It is meant to be read linearly and progresses from beginner topics to advanced topics. We will start by creating a simple [pingable node](#pingable-node-part-1) while skipping over most of the gritty details. Then we'll move on to a full [client-server socket application](#client-and-server-part-2) where we will take the occasional tangent to learn more about how all of this works. Source code for the examples can be found here: <a href="https://github.com/zerotier/libzt/tree/main/examples">libzt/examples</a>. For API reference documentation see the sidebar to the left. To read more more about how ZeroTier works in general, see our [Design Whitepaper](https://docs.zerotier.com/zerotier/manual). If you find an error on this page or you just need help getting something to work please open a [GitHub issue](https://github.com/zerotier/libzt/issues).
+This guide explains how to use the ZeroTier SDK Socket API. It is meant to be read linearly and progresses from beginner topics to advanced topics. We will start by creating a simple [pingable node](#pingable-node-part-1) while skipping over most of the gritty details. Then we'll move on to a full [client-server socket application](#client-and-server-part-2) where we will take the occasional tangent to learn more about how all of this works. Source code for the examples can be found here: <a href="https://github.com/zerotier/libzt/tree/main/examples">libzt/examples</a>. For API reference documentation see the sidebar to the left. To read more more about how ZeroTier works in general, see our [Design Whitepaper](/zerotier/manual). If you find an error on this page or you just need help getting something to work please open a [GitHub issue](https://github.com/zerotier/libzt/issues).
 
 ## Install
 
@@ -1606,9 +1606,9 @@ This section will show you how to use the built-in Central API to make calls to 
 
 :::note BETA
 
-The Central API built into libzt is still `beta` and is not included in most builds by default. It is currently only available in `C` and can be enabled by commenting out `#define ZTS_DISABLE_CENTRAL_API 1` in `ZeroTierSockets.h`. You will need your system's edition of the `libcurl` development headers and libraries. This exercise is left to the reader for the time being.
+The Central API built into libzt is still `beta` and is not included in most builds by default. It is currently only available in `C` and can be enabled by commenting out `#define ZTS_DISABLE_CENTRAL_API 1` in `ZeroTierSockets.h`. You will need your system's edition of the `libcurl` development headers and libraries.
 
-You should try to use our API exposed here instead: <a href="https://apidocs.zerotier.com/">apidocs.zerotier.com</a>.
+You can read more about the [Central API spec](/api/central) to learn more about the capabilities is exposes.
 :::
 
 ## Common issues
@@ -1642,7 +1642,7 @@ If the information in those sections hasn't helped, there are a couple of ways t
 
 ## Self-hosting
 
-We expend considerable effort designing and maintaining a robust and globally available constellation of root servers and redundant network controllers but we understand that security practices may require you to function independently from our infrastructure. For this reason we try to make it as easy as possible to set up your own infrastructure: See [here](https://github.com/zerotier/ZeroTierOne/tree/main/controller) to learn more about how to set up your own network controller, and [here](https://docs.zerotier.com/zerotier/moons) to learn more about setting up your own roots.
+We expend considerable effort designing and maintaining a robust and globally available constellation of root servers and redundant network controllers but we understand that security practices may require you to function independently from our infrastructure. For this reason we try to make it as easy as possible to set up your own infrastructure: See [here](https://github.com/zerotier/ZeroTierOne/tree/main/controller) to learn more about how to set up your own network controller, and [here](/zerotier/moons) to learn more about setting up your own roots.
 
 ## Technical notes
 

--- a/docs/terraform-multicloud.md
+++ b/docs/terraform-multicloud.md
@@ -18,7 +18,7 @@ And I am an ephemeral girl<br/>
 
 This quickstart tutorial creates a lab environment for using ZeroTier
 in combination with multiple Terraform cloud providers. If you're a
-ZeroTier user that's new to Terraform, You might be looking for the [Terraform Quickstart](https://docs.zerotier.com/terraform/quickstart) instead.
+ZeroTier user that's new to Terraform, You might be looking for the [Terraform Quickstart](/terraform) instead.
 
 If you're a Terraform user that's new to ZeroTier, you're in the right place. Make yourself a coffee and and buckle up.
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -347,6 +347,6 @@ When you're done experimenting with ZeroTier and Terraform, tear everything down
 
 ## That's all folks
 
-If you like this tutorial, check out the [ZeroTier Multicloud Terraform Quickstart](https://docs.zerotier.com/terraform/multicloud-quickstart) next!
+If you like this tutorial, check out the [ZeroTier Multicloud Terraform Quickstart](/terraform/multicloud-quickstart) next!
 
 -s

--- a/docs/what-is-a-controller.md
+++ b/docs/what-is-a-controller.md
@@ -47,7 +47,7 @@ While networks with any valid ID can be added to the controller's database, it w
 
 The controller JSON API is *very* sensitive about types. Integers must be integers and strings strings, etc. Incorrect types may be ignored, set to default values, or set to undefined values.
 
-Full documentation of the Controller API can be found on our [documentation site](https://docs.zerotier.com/service/v1#tag/controller)
+Full documentation of the Controller API can be found on our [documentation site](/service/v1#tag/controller)
 
 ### Prometheus Metrics
 


### PR DESCRIPTION
I'm hoping this will make the link checker happy, so normal CI builds of the site can proceed.