### PR TITLE
fix central + service api doc links

### DIFF
--- a/docs/api/central/index.md
+++ b/docs/api/central/index.md
@@ -6,6 +6,6 @@ description: >
 
 [Central](/central) is our hosted control plane for ZeroTierOne networks.
 
-In addition to the web-based GUI, you can use the [Central API](/central/v1) to view and manage your networks. You will need an [API token](/api/tokens#zerotier-central-token) for access.
+In addition to the web-based GUI, you can use the [Central API](/api/central/ref-v1) to view and manage your networks. You will need an [API token](/api/tokens#zerotier-central-token) for access.
 
 You can write your own client code to connect with Central using our [examples](/api/central/examples) as a starting point, or use an existing integration like our [Terraform provider](/terraform).

--- a/docs/api/service/index.md
+++ b/docs/api/service/index.md
@@ -6,4 +6,4 @@ description: >
 
 The ZeroTierOne service provides an API which is used by the [ZeroTierOne CLI](/cli) and other clients to manage settings on your local instance of ZeroTier. This administration API is restricted to `localhost` by default, and requires authentication using an [API token](/api/tokens#zerotierone-service-token).
 
-Once you have your local token, you can access [local node, network, and peer information](/service/v1), as well as configuring a [standalone controller](/controller).
+Once you have your local token, you can access [local node, network, and peer information](/api/service/ref-v1), as well as configuring a [standalone controller](/controller).

--- a/docs/controller.md
+++ b/docs/controller.md
@@ -17,7 +17,7 @@ First, skim the [README](https://github.com/zerotier/ZeroTierOne/tree/master/con
 We're going to use `curl` to set up an example ZeroTier network. An easy way to get `curl` in Windows is to install [the latest version of Git](https://git-scm.com/downloads), which comes with bash, curl, and other tools.
 
 :::info OpenAPI
-The setup described here uses the local [ZeroTierOne service API](/api/service) to provision and manage networks. You can [browse](/service/v1#tag/controller) the OpenAPI docs for the local controller API for more detail on this interface.
+The setup described here uses the local [ZeroTierOne service API](/api/service) to provision and manage networks. You can [browse](/api/service/ref-v1#tag/controller) the OpenAPI docs for the local controller API for more detail on this interface.
 :::
 
 This is a low tech way to setup a controller for example purposes. You'd likely build yourself something fancier around this API.

--- a/docs/sockets.md
+++ b/docs/sockets.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Encrypted P2P connections for your app or service.
 
-This guide explains how to use the ZeroTier SDK Socket API. It is meant to be read linearly and progresses from beginner topics to advanced topics. We will start by creating a simple [pingable node](#pingable-node-part-1) while skipping over most of the gritty details. Then we'll move on to a full [client-server socket application](#client-and-server-part-2) where we will take the occasional tangent to learn more about how all of this works. Source code for the examples can be found here: <a href="https://github.com/zerotier/libzt/tree/main/examples">libzt/examples</a>. For API reference documentation see the sidebar to the left. To read more more about how ZeroTier works in general, see our [Design Whitepaper](/zerotier/manual). If you find an error on this page or you just need help getting something to work please open a [GitHub issue](https://github.com/zerotier/libzt/issues).
+This guide explains how to use the ZeroTier SDK Socket API. It is meant to be read linearly and progresses from beginner topics to advanced topics. We will start by creating a simple [pingable node](#pingable-node-part-1) while skipping over most of the gritty details. Then we'll move on to a full [client-server socket application](#client-and-server-part-2) where we will take the occasional tangent to learn more about how all of this works. Source code for the examples can be found here: <a href="https://github.com/zerotier/libzt/tree/main/examples">libzt/examples</a>. For API reference documentation see the sidebar to the left. To read more more about how ZeroTier works in general, see our [Design Whitepaper](/protocol). If you find an error on this page or you just need help getting something to work please open a [GitHub issue](https://github.com/zerotier/libzt/issues).
 
 ## Install
 
@@ -1642,7 +1642,7 @@ If the information in those sections hasn't helped, there are a couple of ways t
 
 ## Self-hosting
 
-We expend considerable effort designing and maintaining a robust and globally available constellation of root servers and redundant network controllers but we understand that security practices may require you to function independently from our infrastructure. For this reason we try to make it as easy as possible to set up your own infrastructure: See [here](https://github.com/zerotier/ZeroTierOne/tree/main/controller) to learn more about how to set up your own network controller, and [here](/zerotier/moons) to learn more about setting up your own roots.
+We expend considerable effort designing and maintaining a robust and globally available constellation of root servers and redundant network controllers but we understand that security practices may require you to function independently from our infrastructure. For this reason we try to make it as easy as possible to set up your own infrastructure: See [here](https://github.com/zerotier/ZeroTierOne/tree/main/controller) to learn more about how to set up your own network controller, and [here](/roots#creating-your-own-roots-aka-moons) to learn more about setting up your own roots.
 
 ## Technical notes
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -347,6 +347,6 @@ When you're done experimenting with ZeroTier and Terraform, tear everything down
 
 ## That's all folks
 
-If you like this tutorial, check out the [ZeroTier Multicloud Terraform Quickstart](/terraform/multicloud-quickstart) next!
+If you like this tutorial, check out the [ZeroTier Multicloud Terraform Quickstart](/terraform-multicloud) next!
 
 -s

--- a/docs/what-is-a-controller.md
+++ b/docs/what-is-a-controller.md
@@ -47,7 +47,7 @@ While networks with any valid ID can be added to the controller's database, it w
 
 The controller JSON API is *very* sensitive about types. Integers must be integers and strings strings, etc. Incorrect types may be ignored, set to default values, or set to undefined values.
 
-Full documentation of the Controller API can be found on our [documentation site](/service/v1#tag/controller)
+Full documentation of the Controller API can be found on our [documentation site](/api/service/ref-v1#tag/controller)
 
 ### Prometheus Metrics
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,11 +137,11 @@ module.exports = {
             },
             {
               label: "Central REST API",
-              to: "/central/v1",
+              to: "/api/central/ref-v1",
             },
             {
               label: "Service REST API",
-              to: "/service/v1",
+              to: "/api/service/ref-v1",
             },
             {
               label: "DNS",
@@ -194,11 +194,11 @@ module.exports = {
       {
         specs: [
           {
-            route: "/central/v1",
+            route: "/api/central/ref-v1",
             spec: "./static/openapi/centralv1.json",
           },
           {
-            route: "/service/v1",
+            route: "/api/service/ref-v1",
             spec: "https://github.com/zerotier/zerotier-one-api-spec/releases/latest/download/openapi.yaml",
           },
         ],

--- a/nginx.conf
+++ b/nginx.conf
@@ -49,6 +49,14 @@ server {
         return 301 /sso;
     }
 
+    location ~ ^/central/v1(/?)$ {
+        return 301 /api/central/ref-v1;
+    }
+
+    location ~ ^/service/v1(/?)$ {
+        return 301 /api/service/ref-v1;
+    }
+
     location ~ ^/sockets/tutorial.html$ {
         return 301 /sockets;
     }

--- a/sidebars.js
+++ b/sidebars.js
@@ -86,7 +86,7 @@ module.exports = {
           items: [
             {
               type: 'html',
-              value: '<a href="/central/v1" target="_new">API Reference (V1)</a>',
+              value: '<a href="/api/central/ref-v1" target="_new">API Reference (V1)</a>',
               defaultStyle: true,
             },
             'api/central/examples',
@@ -99,7 +99,7 @@ module.exports = {
           items: [
             {
               type: 'html',
-              value: '<a href="/service/v1" target="_new">API Reference (V1)</a>',
+              value: '<a href="/api/service/ref-v1" target="_new">API Reference (V1)</a>',
               defaultStyle: true,
             },
           ],

--- a/static/openapi/centralv1.json
+++ b/static/openapi/centralv1.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "description": "ZeroTier Central Network Management Portal API.<p>All API requests must have an API token header specified in the <code>Authorization: token xxxxx</code> format.  You can generate your API key by logging into <a href=\"https://my.zerotier.com\">ZeroTier Central</a> and creating a token on the Account page.</p><p>eg. <code>curl -X GET -H \"Authorization: token xxxxx\" https://api.zerotier.com/api/v1/network</code></p><p><h3>Rate Limiting</h3></p><p>The ZeroTier Central API implements rate limiting.  Paid users are limited to 100 requests per second.  Free users are limited to 20 requests per second.</p> <p> You can get the OpenAPI spec here as well: <code>https://docs.zerotier.com/openapi/centralv1.json</code></p>",
+    "description": "ZeroTier Central Network Management Portal API.<p>All API requests must have an API token header specified in the <code>Authorization: token xxxxx</code> format.  You can generate your API key by logging into <a href=\"https://my.zerotier.com\">ZeroTier Central</a> and creating a token on the Account page.</p><p>eg. <code>curl -X GET -H \"Authorization: token xxxxx\" https://api.zerotier.com/api/v1/network</code></p><p><h3>Rate Limiting</h3></p><p>The ZeroTier Central API implements rate limiting.  Paid users are limited to 100 requests per second.  Free users are limited to 20 requests per second.</p> <p> You can get the OpenAPI spec here as well: <code>https://docs.zerotier.com/api/central/ref-v1.json</code></p>",
     "version": "v1",
     "title": "ZeroTier Central API",
     "contact": {


### PR DESCRIPTION
Update URLs for default OpenAPI spec docs, and add Nginx rewrites to serve legacy paths.

Should address #171.