### PR TITLE
Use newer yarn to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ buildx:
 	@echo docker buildx inspect --bootstrap
 
 all:
+	corepack enable && corepack prepare yarn@4.1.1
 	yarn install
 	NODE_OPTIONS=--openssl-legacy-provider yarn lint
 	NODE_OPTIONS=--openssl-legacy-provider yarn build


### PR DESCRIPTION
locally, building with yarn 1 reproduces the no api docs issues. This makes it use yarn 4, which works locally. 