### PR TITLE
add ssoExempt property to central api spec

### DIFF
--- a/static/openapi/centralv1.json
+++ b/static/openapi/centralv1.json
@@ -1379,6 +1379,13 @@
             "example": 123,
             "nullable": true
           },
+          "ssoExempt": {
+            "type": "boolean",
+            "readOnly": false,
+            "description": "Allow the member to be authorized without OIDC/SSO",
+            "example": false,
+            "nullable": true
+          },
           "tags": {
             "type": "array",
             "items": {


### PR DESCRIPTION
I copied this over to go-ztcentral, and the tests still pass, but it's not much of a signal. 
<img width="399" alt="Screenshot 2024-08-15 at 8 54 40 AM" src="https://github.com/user-attachments/assets/c0231408-b811-4df7-86f3-16c9fc51f5be">
