### PR TITLE
Add Windows ping command in ZeroTier installation tutorial

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -365,6 +365,8 @@ Try switching your phone from wifi to cell and back. It may take about a minute,
 
 ### Try the ping command
 
+For macOS and Linux users, you are going to do the following.
+
 Back in the Command Line / Terminal that you just opened:
 
 - type `ping -c 5 $ZEROTIER_IP_ADDRESS` `<enter>` into your command line.
@@ -412,6 +414,27 @@ PING 192.168.123.234 (192.168.123.234): 56 data bytes
 92 bytes from 192.168.82.1: Destination Port Unreachable
 Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
  4  5  00 5400 56e7   0 0000  3f  01 d4ad 192.168.82.217  192.168.123.234
+```
+
+For Windows users, the `-c` parameter is explianed as something else. If you want to send 5 packages, you will do the following.
+
+- type `ping -n 5 $ZEROTIER_IP_ADDRESS` `<enter>` into your command line.
+
+A successful `ping`:
+
+```sh
+C:\> ping -n 5 172.22.217.93
+Pinging 172.22.217.93 with 32 bytes of data
+Reply from 172.22.217.93: bytes=32 time=22ms TTL=64 
+Reply from 172.22.217.93: bytes=32 time=10ms TTL=64 
+Reply from 172.22.217.93: bytes=32 time=9ms TTL=64 
+Reply from 172.22.217.93: bytes=32 time=7ms TTL=64 
+Reply from 172.22.217.93: bytes=32 time=9ms TTL=64 
+
+Ping statistics for 172.22.217.93:
+    Packets: Sent = 5, Received = 5, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 5ms, Maximum = 7ms, Average = 6ms
 ```
 
 There may just be a typo in the IP address. Double check that your device is authorized at my.zerotier.com

--- a/docs/start.md
+++ b/docs/start.md
@@ -416,7 +416,7 @@ Vr HL TOS  Len   ID Flg  off TTL Pro  cks      Src      Dst
  4  5  00 5400 56e7   0 0000  3f  01 d4ad 192.168.82.217  192.168.123.234
 ```
 
-For Windows users, the `-c` parameter is explianed as something else. If you want to send 5 packages, you will do the following.
+For Windows users, the `-c` parameter is explained as something else. If you want to send 5 packages, you will do the following.
 
 - type `ping -n 5 $ZEROTIER_IP_ADDRESS` `<enter>` into your command line.
 


### PR DESCRIPTION
The ZeroTier installation tutorial only mentioned the ping command for Linux and macOS, which is `ping -c 5 <ip>`. This caused confusion for Windows users.

Changed the command to `ping -n 5 <ip>' for Windows, which is the correct syntax. Additionally, added the expected output of the Windows ping command to clarify the result for users.