### PR TITLE
Disable posthog recording

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,7 @@ module.exports = {
         apiKey: apiKey,
         appUrl: appUrl,
         enableInDevelopment: false,
+        disable_session_recording: true,
       },
     ],
   ],


### PR DESCRIPTION
No one is watching these AFAIK and they are
not cheap at this level of traffic.
We might turn them on on sites with less traffic or beta sites and this being off here will reduce noise and cost.

