### PR TITLE
Updates our GH action config to add search engine defaults.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @laduke @danitheturtle @rcoder @glimberg @joseph-henry @aaronjohnson @zt-grant @constantijn @rokjoana @duygu @zerotier/dev @Fightersbane
+@zerotier/dev @Fightersbane @rcoder @aaronjohnson 

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -48,7 +48,9 @@ jobs:
         NODE_OPTIONS: --openssl-legacy-provider
         POSTHOG_API_HOST: ${{ secrets.POSTHOG_API_HOST }}
         POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
-
+        ALGOLIA_API_KEY: ${{ vars.ALGOLIA_API_KEY }}
+        ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
+        ALGOLIA_INDEX_NAME: ${{ env.ALGOLIA_INDEX_NAME }}
     - id: 'auth'
       uses: 'google-github-actions/auth@v2'
       with:

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -45,6 +45,9 @@ jobs:
         NODE_OPTIONS: --openssl-legacy-provider
         POSTHOG_API_HOST: ${{ secrets.POSTHOG_API_HOST }}
         POSTHOG_PROJECT_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+        ALGOLIA_API_KEY: ${{ vars.ALGOLIA_API_KEY }}
+        ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
+        ALGOLIA_INDEX_NAME: ${{ env.ALGOLIA_INDEX_NAME }}
 
     - id: 'auth'
       uses: 'google-github-actions/auth@v2'


### PR DESCRIPTION
The Algolia search plugin (being added in another branch) requires some default environment variables to be set. Unfortunately, GitHub will only run the workflow defs currently in 'main', so the changes made in that branch (cherry-picked here) have to get merged before CI can run on the fature branch.